### PR TITLE
ci: Add arm64 support and fix docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,14 @@ jobs:
         with:
           submodules: true
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -63,5 +71,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           build-args: |
             GIT_REVISION=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # syntax=docker/dockerfile:1
 
 # ---- Builder ----
-FROM node:18-alpine AS builder
+FROM node:18-slim AS builder
+
+RUN apt-get update && apt-get install -y openssl
 
 ARG GIT_REVISION
 ENV GIT_REVISION=${GIT_REVISION}
@@ -19,7 +21,9 @@ RUN yarn generate
 RUN yarn build
 
 # ---- Dependencies ----
-FROM node:18-alpine AS deps
+FROM node:18-slim AS deps
+
+RUN apt-get update && apt-get install -y openssl
 
 WORKDIR /deps
 
@@ -32,9 +36,9 @@ RUN yarn generate
 RUN yarn preload-geolite
 
 # ---- Runner ----
-FROM node:18-alpine
+FROM node:18-slim
 
-RUN apk add dumb-init
+RUN apt-get update && apt-get install -y openssl dumb-init
 
 WORKDIR /app
 


### PR DESCRIPTION
Adds arm64 docker containers

Workarounds https://github.com/prisma/prisma/issues/16553 by switching to [slim + openssl instead alpine](https://github.com/prisma/prisma/issues/16232#issuecomment-1336481295) (another solution would be to stick to alpine3.16 but [prisma doesn't support arm64 alpine](https://github.com/prisma/prisma/issues/15306))
